### PR TITLE
fixed import dependencies in geoip2.models

### DIFF
--- a/geoip2/database.py
+++ b/geoip2/database.py
@@ -6,6 +6,7 @@ GeoIP2 Database Reader
 """
 import geoip2
 import geoip2.models
+import geoip2.errors
 import maxminddb
 
 

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -7,7 +7,6 @@ import sys
 sys.path.append('..')
 
 import geoip2.database
-import geoip2.errors
 
 if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest


### PR DESCRIPTION
In using geoip2.database outside of database_test, AttributeError was being raised instead of AddressNotFoundError since geoip2.errors was not imported. geoip2.database should be responsible for loading all of its dependencies, and not depend on the caller for that. Having geoip2.errors imported in database_test masked this missing dependency.

I removed the import from database_test, verified that the existing tests exhibited the problem I was having, and then added the import into database.py, and verified that the tests were running cleanly again.
