### PR TITLE
Require requests_mock version at least 0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     extras_require={
         ':python_version=="2.6" or python_version=="2.7"': ['ipaddress']
     },
-    tests_require=['requests_mock'],
+    tests_require=['requests_mock>=0.5'],
     test_suite="tests",
     license=geoip2.__license__,
     classifiers=[


### PR DESCRIPTION
This was first version with mock() function and there are distributions
(Debian Jessie) which still have older Python requests mock library.