### PR TITLE
Adding Unicode (Emoji) flags to Country

### DIFF
--- a/geoip2/records.py
+++ b/geoip2/records.py
@@ -17,10 +17,13 @@ class Record(SimpleEquality):
     __metaclass__ = ABCMeta
 
     _valid_attributes = set()
+    _computed_attributes = set()
 
     def __init__(self, **kwargs):
         valid_args = dict((k, kwargs.get(k)) for k in self._valid_attributes)
         self.__dict__.update(valid_args)
+        computed_args = dict((k, getattr(self, k)(valid_args)) for k in self._computed_attributes)
+        self.__dict__.update(computed_args)
 
     def __setattr__(self, name, value):
         raise AttributeError("can't set attribute")


### PR DESCRIPTION
## Intended Functionality  
The following python code
```
response = reader.city('128.101.101.101')
print(response.country.flag)
```
Produces this output:
🇺🇸

## Implementation
The conversion from ISO3166 Country Code to a Unicode flag is actually quite trivial.

We add an offset to the ASCII character representing where the [Regional Indicator Symbol](https://en.wikipedia.org/wiki/Regional_Indicator_Symbol) would start. And if we do this for both letters in the iso code, we can produce a single Unicode character representing that Country's flag.  [See this blog entry for more.](http://schinckel.net/2015/10/29/unicode-flags-in-python/)

I'm not sure where to add testcases, records doesn't have unit tests.  Could one of the maintainers point me in the right direction?