### PR TITLE
Add trove classifier for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python',
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Internet',


### PR DESCRIPTION
Hi!

This small PR adds a trove classifier for Python 3.6. Because the classifier is missing, the library cannot be installed on Python 3.6 because it can't be found.