### PR TITLE
Adds ability to pass an open file descriptor to the Reader class.

### DIFF
--- a/geoip2/database.py
+++ b/geoip2/database.py
@@ -9,7 +9,7 @@ import inspect
 import maxminddb
 # pylint: disable=unused-import
 from maxminddb import (MODE_AUTO, MODE_MMAP, MODE_MMAP_EXT, MODE_FILE,
-                       MODE_MEMORY)
+                       MODE_MEMORY, MODE_FD)
 
 import geoip2
 import geoip2.models
@@ -23,9 +23,9 @@ class Reader(object):
     IP addresses can be looked up using the ``country`` and ``city`` methods.
 
     The basic API for this class is the same for every database. First, you
-    create a reader object, specifying a file name. You then call the method
-    corresponding to the specific database, passing it the IP address you want
-    to look up.
+    create a reader object, specifying a file name or file descriptor.
+    You then call the method corresponding to the specific database, passing
+    it the IP address you want to look up.
 
     If the request succeeds, the method call will return a model class for the
     method you called. This model in turn contains multiple record classes,
@@ -40,10 +40,12 @@ class Reader(object):
 
 """
 
-    def __init__(self, filename, locales=None, mode=MODE_AUTO):
+    def __init__(self, fileish, locales=None, mode=MODE_AUTO):
         """Create GeoIP2 Reader.
 
-        :param filename: The path to the GeoIP2 database.
+        :param fileish: The string path to the GeoIP2 database, or an existing
+          file descriptor pointing to the database. Note that this latter
+          usage is only valid when mode is MODE_FD.
         :param locales: This is list of locale codes. This argument will be
           passed on to record classes to use when their name properties are
           called. The default value is ['en'].
@@ -73,13 +75,15 @@ class Reader(object):
           * MODE_MMAP - read from memory map. Pure Python.
           * MODE_FILE - read database as standard file. Pure Python.
           * MODE_MEMORY - load database into memory. Pure Python.
+          * MODE_FD - the param passed via fileish is a file descriptor, not a
+             path. This mode implies MODE_MEMORY. Pure Python.
           * MODE_AUTO - try MODE_MMAP_EXT, MODE_MMAP, MODE_FILE in that order.
              Default.
 
         """
         if locales is None:
             locales = ['en']
-        self._db_reader = maxminddb.open_database(filename, mode)
+        self._db_reader = maxminddb.open_database(fileish, mode)
         self._locales = locales
 
     def __enter__(self):

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -25,7 +25,6 @@ if sys.version_info[0] == 2:
 
 
 class BaseTestReader(object):
-
     def test_language_list(self):
         reader = geoip2.database.Reader(
             'tests/data/test-data/GeoIP2-Country-Test.mmdb',

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -25,6 +25,7 @@ if sys.version_info[0] == 2:
 
 
 class BaseTestReader(object):
+
     def test_language_list(self):
         reader = geoip2.database.Reader(
             'tests/data/test-data/GeoIP2-Country-Test.mmdb',
@@ -214,6 +215,10 @@ class TestFileReader(BaseTestReader, unittest.TestCase):
 
 class TestMemoryReader(BaseTestReader, unittest.TestCase):
     mode = geoip2.database.MODE_MEMORY
+
+
+class TestFDReader(unittest.TestCase):
+    mode = geoip2.database.MODE_FD
 
 
 class TestAutoReader(BaseTestReader, unittest.TestCase):


### PR DESCRIPTION
This small PR is complementary to maxmind/MaxMind-DB-Reader-python#33, allowing one to pass an open file descriptor to the `Reader()` class upon instantiation (instead of just a string path to the database). The comments in the PR just referenced include a longer reasoning/use-case for this functionality.

Since none of the current unit tests instantiate a `Reader()` object with an explicit `mode`, I've just added a small stub test class named `TestFDReader` (not a subclass of `BaseTesteReader`), which currently does nothing. It's a placeholder and reminder that it could be used in the future.