### PR TITLE
Add missing catchall kwargs for records

### DIFF
--- a/geoip2/records.py
+++ b/geoip2/records.py
@@ -356,18 +356,17 @@ class Location(Record):
       :type: unicode
 
     """
-    def __init__(
-            self,
-            average_income=None,
-            accuracy_radius=None,
-            latitude=None,
-            longitude=None,
-            metro_code=None,
-            population_density=None,
-            postal_code=None,
-            postal_confidence=None,
-            time_zone=None,
-    ):
+    def __init__(self,
+                 average_income=None,
+                 accuracy_radius=None,
+                 latitude=None,
+                 longitude=None,
+                 metro_code=None,
+                 population_density=None,
+                 postal_code=None,
+                 postal_confidence=None,
+                 time_zone=None,
+                 **_):
         self.average_income = average_income
         self.accuracy_radius = accuracy_radius
         self.latitude = latitude
@@ -392,10 +391,7 @@ class MaxMind(Record):
       :type: int
 
     """
-    def __init__(
-            self,
-            queries_remaining=None,
-    ):
+    def __init__(self, queries_remaining=None, **_):
         self.queries_remaining = queries_remaining
 
 
@@ -426,7 +422,7 @@ class Postal(Record):
       :type: int
 
     """
-    def __init__(self, code=None, confidence=None):
+    def __init__(self, code=None, confidence=None, **_):
         self.code = code
         self.confidence = confidence
 

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -294,6 +294,47 @@ class TestModels(unittest.TestCase):
 
     def test_unknown_keys(self):
         model = geoip2.models.City({
+            'city': {
+                'invalid': 0
+            },
+            'continent': {
+                'invalid': 0,
+                'names': {
+                    'invalid': 0
+                },
+            },
+            'country': {
+                'invalid': 0,
+                'names': {
+                    'invalid': 0
+                },
+            },
+            'location': {
+                'invalid': 0
+            },
+            'postal': {
+                'invalid': 0
+            },
+            'subdivisions': [
+                {
+                    'invalid': 0,
+                    'names': {
+                        'invalid': 0,
+                    },
+                },
+            ],
+            'registered_country': {
+                'invalid': 0,
+                'names': {
+                    'invalid': 0,
+                },
+            },
+            'represented_country': {
+                'invalid': 0,
+                'names': {
+                    'invalid': 0,
+                },
+            },
             'traits': {
                 'ip_address': '1.2.3.4',
                 'invalid': 'blah'


### PR DESCRIPTION
This is necessary so the constructor doesn't blow up when we add new
keys in the future.