### PR TITLE
Require older yapf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ before_install:
   - "if [[ $RUN_SNYK && $SNYK_TOKEN ]]; then sudo apt-get install -y nodejs; npm install -g snyk; fi"
 install:
   - pip install -r requirements.txt
-  - pip install requests_mock pylint coveralls yapf
+  # We require yapf 0.28.0 to work around https://github.com/google/yapf/issues/781
+  # If that issue is resolved, we should remove the version constraint.
+  - pip install requests_mock pylint coveralls yapf==0.28.0
   - "if [[ $RUN_SNYK && $SNYK_TOKEN ]]; then snyk test --org=maxmind; fi"
 script:
   - coverage run --source=geoip2 setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       dist: trusty
     - python: 3.7
       dist: xenial
+    - python: 3.8
+      dist: xenial
       env:
         - RUN_SNYK=1
         - RUN_LINTER=1


### PR DESCRIPTION
With 0.29.0, we ran into https://github.com/google/yapf/issues/781,
which made pylint unhappy and makes the arg list harder to read.