### PR TITLE
Add project source URL to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,7 @@ setup(
         "Topic :: Internet :: Proxy Servers",
         "Topic :: Internet",
     ],
+    project_urls={
+        "Source": "https://github.com/maxmind/GeoIP2-python",
+    },
 )


### PR DESCRIPTION
I received a PR from @dependabot to update this geoip2 in my project, but all the links in the pull request were sending me to another project: `https://github.com/maxmind/libmaxminddb` which doesn't seem right. Similarly, the [project page on PyPI](https://pypi.org/project/geoip2/4.5.0/) doesn't link back to the source code, which isn't very convenient.

This will add a link to this GitHub repo on PyPI, and hopefully will also provide more info for Dependabot. We can also add a [link to the documentation](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls), I can add it, if you'd like.