### PR TITLE
Update tests for new mocket version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.7",
     install_requires=requirements,
-    tests_require=["mocket>=3.8.9"],
+    tests_require=["mocket>=3.11.0"],
     test_suite="tests",
     license=geoip2.__license__,
     classifiers=[

--- a/tests/webservice_test.py
+++ b/tests/webservice_test.py
@@ -298,16 +298,18 @@ class TestBaseClient(unittest.TestCase):
         self.assertEqual(
             request.path, "/geoip/v2.1/country/1.2.3.4", "correct URI is used"
         )
-        self.assertEqual(
-            request.headers["Accept"], "application/json", "correct Accept header"
-        )
+
+        # This is to prevent breakage if header normalization in Mocket
+        # changes again in the future.
+        headers = {k.lower(): v for k, v in request.headers.items()}
+        self.assertEqual(headers["accept"], "application/json", "correct Accept header")
         self.assertRegex(
-            request.headers["User-Agent"],
+            headers["user-agent"],
             "^GeoIP2-Python-Client/",
             "Correct User-Agent",
         )
         self.assertEqual(
-            request.headers["Authorization"],
+            headers["authorization"],
             "Basic NDI6YWJjZGVmMTIzNDU2",
             "correct auth",
         )


### PR DESCRIPTION
Mocket 3.11.0 switched to a new package for parsing HTTP requests. This
changed the header normalization. Unfortunately, the library does not
seem to expose a method on the request object that normalizes the
header name before checking for it; as such, we normalize them
to lowercase ourselves.
