### PR TITLE
Pin mocket to 3.12.6 due to tests timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "mocket>=3.12.3",
+    "mocket>=3.12.3,<3.12.7",
 ]
 
 [tool.setuptools.package-data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python =
 
 [testenv:{py38,py39,py310,py311,py312}-test]
 deps =
-    mocket
+    mocket==3.12.6
     pytest
 
     # explicitly require indirect dependency to fix build failure.


### PR DESCRIPTION
Changes in mocked v3.12.7 caused tests timeouts https://github.com/mindflayer/python-mocket/compare/3.12.6...3.12.7.