### PR TITLE
remove setuptools from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel"]
+requires = ["setuptools>=61", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +13,6 @@ dependencies = [
     "aiohttp>=3.6.2,<4.0.0",
     "maxminddb>=2.5.1,<3.0.0",
     "requests>=2.24.0,<3.0.0",
-    "setuptools>=60.0.0",
 ]
 requires-python = ">=3.8"
 readme = "README.rst"


### PR DESCRIPTION
setuptools is a build dependency, it's already listed in the `[build-system]` of pyproject.toml, it is not needed at runtime.

You also don't need `wheel` to just produce a wheel.