### PR TITLE
Make `aiohttp` and `requests` optional dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ To install the ``geoip2`` module, type:
 .. code-block:: bash
 
     $ pip install geoip2
+    $ pip install geoip2[aiohttp]  # Install aiohttp as well
+    $ pip install geoip2[requests]   # Install requests as well
 
 If you are not able to install from PyPI, you may also use ``pip`` from the
 source directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ authors = [
     {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},
 ]
 dependencies = [
-    "aiohttp>=3.14.1,<4.0.0",
     "maxminddb>=3.0.0,<4.0.0",
-    "requests>=2.24.0,<3.0.0",
 ]
 requires-python = ">=3.10"
 readme = "README.rst"
@@ -28,6 +26,14 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Internet",
     "Topic :: Internet :: Proxy Servers",
+]
+
+[project.optional-dependencies]
+aiohttp = [
+    "aiohttp>=3.14.1,<4.0.0",
+]
+requests = [
+    "requests>=2.24.0,<3.0.0",
 ]
 
 [dependency-groups]
@@ -115,6 +121,10 @@ commands = [
 [tool.tox.env.lint]
 description = "Code linting"
 python = "3.14"
+extras = [
+    "aiohttp",
+    "requests",
+]
 dependency_groups = [
     "dev",
     "lint",

--- a/src/geoip2/webservice.py
+++ b/src/geoip2/webservice.py
@@ -27,10 +27,18 @@ import ipaddress
 import json
 from typing import TYPE_CHECKING, cast
 
-import aiohttp
-import aiohttp.http
-import requests
-import requests.utils
+try:
+    import aiohttp
+    import aiohttp.http
+except ImportError:
+    aiohttp = None  # type: ignore[assignment]
+
+try:
+    import requests
+    import requests.utils
+except ImportError:
+    requests = None  # type: ignore[assignment]
+
 
 import geoip2
 import geoip2.models
@@ -51,14 +59,6 @@ if TYPE_CHECKING:
 
     from geoip2.models import City, Country, Insights
     from geoip2.types import IPAddress
-
-_AIOHTTP_UA = (
-    f"GeoIP2-Python-Client/{geoip2.__version__} {aiohttp.http.SERVER_SOFTWARE}"
-)
-
-_REQUEST_UA = (
-    f"GeoIP2-Python-Client/{geoip2.__version__} {requests.utils.default_user_agent()}"
-)
 
 
 class BaseClient:
@@ -352,7 +352,15 @@ class AsyncClient(BaseClient):
         )
 
     async def _session(self) -> aiohttp.ClientSession:
+        if aiohttp is None:
+            msg = "aiohttp is required for async mode; install `GeoIP2[aiohttp]`"
+            raise ImportError(msg)
+
         if not hasattr(self, "_existing_session"):
+            user_agent = (
+                f"GeoIP2-Python-Client/{geoip2.__version__} "
+                f"{aiohttp.http.SERVER_SOFTWARE}"
+            )
             self._existing_session = aiohttp.ClientSession(
                 headers={
                     "Accept": "application/json",
@@ -360,7 +368,7 @@ class AsyncClient(BaseClient):
                         self._account_id,
                         self._license_key,
                     ),
-                    "User-Agent": _AIOHTTP_UA,
+                    "User-Agent": user_agent,
                 },
                 timeout=aiohttp.ClientTimeout(total=self._timeout),
             )
@@ -474,7 +482,10 @@ class Client(BaseClient):
         self._session = requests.Session()
         self._session.auth = (self._account_id, self._license_key)
         self._session.headers["Accept"] = "application/json"
-        self._session.headers["User-Agent"] = _REQUEST_UA
+        self._session.headers["User-Agent"] = (
+            f"GeoIP2-Python-Client/{geoip2.__version__}"
+            f" {requests.utils.default_user_agent()}"
+        )
         if proxy is None:
             self._proxies = None
         else:

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -1,10 +1,7 @@
 import datetime
 import ipaddress
-import sys
 import unittest
 from unittest.mock import MagicMock, patch
-
-sys.path.append("..")
 
 import maxminddb
 

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,10 +1,7 @@
 import datetime
 import ipaddress
-import sys
 import unittest
 from typing import ClassVar
-
-sys.path.append("..")
 
 import geoip2.models
 

--- a/tests/webservice_test.py
+++ b/tests/webservice_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import ipaddress
-import sys
 import unittest
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -13,7 +12,6 @@ import pytest
 import pytest_httpserver
 from pytest_httpserver import HeaderValueMatcher
 
-sys.path.append("..")
 import geoip2
 from geoip2.errors import (
     AddressNotFoundError,

--- a/tests/webservice_test.py
+++ b/tests/webservice_test.py
@@ -403,6 +403,7 @@ class TestClient(TestBaseClient):
     client: Client
 
     def setUp(self) -> None:
+        pytest.importorskip("requests")
         self.client_class = Client
         self.client = Client(42, "abcdef123456")
         self.client._base_uri = self.httpserver.url_for("/geoip/v2.1")  # noqa: SLF001
@@ -416,6 +417,7 @@ class TestAsyncClient(TestBaseClient):
     client: AsyncClient
 
     def setUp(self) -> None:
+        pytest.importorskip("aiohttp")
         self._loop = asyncio.new_event_loop()
         self.client_class = AsyncClient
         self.client = AsyncClient(42, "abcdef123456")

--- a/uv.lock
+++ b/uv.lock
@@ -441,8 +441,14 @@ name = "geoip2"
 version = "5.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiohttp" },
     { name = "maxminddb" },
+]
+
+[package.optional-dependencies]
+aiohttp = [
+    { name = "aiohttp" },
+]
+requests = [
     { name = "requests" },
 ]
 
@@ -459,10 +465,11 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.1,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.14.1,<4.0.0" },
     { name = "maxminddb", specifier = ">=3.0.0,<4.0.0" },
-    { name = "requests", specifier = ">=2.24.0,<3.0.0" },
+    { name = "requests", marker = "extra == 'requests'", specifier = ">=2.24.0,<3.0.0" },
 ]
+provides-extras = ["aiohttp", "requests"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This PR makes `aiohttp` and `requests`, only required for `geoip2.webservice`, optional dependencies.

They can be installed separately (many projects will likely have `requests` anyway), or using the extras provided, i.e.

```
pip install GeoIP2[aiohttp,requests]
```

to use the version range specified by requirements.

The Tox configuration is adjusted so tests are run both with and without the libraries installed.

This fixes #101 (makes it possible to install without the webservice bits).
This closes #104 (supersedes it to work with the current packaging and testing infrastructure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional installation extras for web service support: `geoip2[aiohttp]` and `geoip2[requests]`.
  - Async client now clearly instructs how to install missing async support.
  - User-Agent is now set dynamically to include both the package version and the underlying HTTP client/server details.
- **Documentation**
  - Updated installation instructions to mention the new optional extras.
- **Tests**
  - Removed import-path workarounds and skip sync/async web service tests when the corresponding optional dependencies aren’t installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->