### PR TITLE
Tests: fix database test to actually pass `mode` through

### DIFF
--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -280,9 +280,5 @@ class TestMemoryReader(BaseTestReader):
     mode = geoip2.database.MODE_MEMORY
 
 
-class TestFDReader(unittest.TestCase):
-    mode = geoip2.database.MODE_FD
-
-
 class TestAutoReader(BaseTestReader):
     mode = geoip2.database.MODE_AUTO


### PR DESCRIPTION
It looks like ever since the `mode` argument was surfaced in 06b1b62edc9732ae77e74a0a30431e4b91886ef1 a decade ago, it was actually never tested; `self.mode` was not used in `BaseTestReader`.

In addition, 3f8c7ca94b0e03bf9bd1f1b50f623b3c151691a0 adds support for `MODE_FD`, but the test suite it added is empty, so it's simply removed here.

This also switches from unittest `self.assert*`s to plain pytest asserts and `pytest.raises()`es.