### PR TITLE
Disable existing too-many-positional-arguments

### DIFF
--- a/geoip2/models.py
+++ b/geoip2/models.py
@@ -471,7 +471,7 @@ class ASN(SimpleModel):
     autonomous_system_number: Optional[int]
     autonomous_system_organization: Optional[str]
 
-    # pylint:disable=too-many-arguments
+    # pylint:disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, raw: Dict[str, Union[str, int]]) -> None:
         super().__init__(raw)
         self.autonomous_system_number = cast(
@@ -623,7 +623,7 @@ class ISP(ASN):
     mobile_network_code: Optional[str]
     organization: Optional[str]
 
-    # pylint:disable=too-many-arguments
+    # pylint:disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, raw: Dict[str, Union[str, int]]) -> None:
         super().__init__(raw)
         self.isp = cast(Optional[str], raw.get("isp"))

--- a/geoip2/records.py
+++ b/geoip2/records.py
@@ -5,7 +5,7 @@ Records
 
 """
 
-# pylint:disable=too-many-arguments,too-many-instance-attributes,too-many-locals
+# pylint:disable=too-many-arguments,too-many-positional-arguments,too-many-instance-attributes,too-many-locals
 
 import ipaddress
 

--- a/geoip2/webservice.py
+++ b/geoip2/webservice.py
@@ -73,7 +73,7 @@ class BaseClient:  # pylint: disable=missing-class-docstring, too-few-public-met
         timeout: float,
     ) -> None:
         """Construct a Client."""
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         if locales is None:
             locales = ["en"]
 
@@ -260,7 +260,7 @@ class AsyncClient(BaseClient):
     _existing_session: aiohttp.ClientSession
     _proxy: Optional[str]
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         account_id: int,
         license_key: str,
@@ -423,7 +423,7 @@ class Client(BaseClient):
     _session: requests.Session
     _proxies: Optional[Dict[str, str]]
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         account_id: int,
         license_key: str,


### PR DESCRIPTION
everywhere we diable too-many-arguments. These rules seem to overlap
unfortunately.
