### PR TITLE
Set Dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,17 @@
 version: 2
 updates:
   - package-ecosystem: uv
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
-      time: "14:00"
+      time: '14:00'
     open-pull-requests-limit: 10
-  - package-ecosystem: "github-actions"
-    directory: "/"
+    cooldown:
+      default-days: 4
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: daily
-      time: "14:00"
+      time: '14:00'
+    cooldown:
+      default-days: 4


### PR DESCRIPTION
This PR sets the Dependabot cooldown period to 4 days for all package ecosystems.

## Context

This addresses zizmor findings that flag missing or insufficient cooldown configuration in dependabot.yml files. The zizmor security tool requires a minimum cooldown of 4 days to avoid potential security issues with rapid dependency updates.

## Changes

- Added/updated `cooldown` configuration with `default-days: 4` for all package ecosystems in `.github/dependabot.yml`

## References

- Linear issue: [ENG-3236](https://linear.app/maxmind/issue/ENG-3236/zizmor-findings-are-addressed)
- zizmor documentation: https://docs.zizmor.sh/audits/#remediation_6
