### PR TITLE
Use single source of truth for version from pyproject.toml

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@
 History
 -------
 
+5.3.0
+++++++++++++++++++
+
+* The version is now retrieved from package metadata at runtime using
+  ``importlib.metadata``. This reduces the chance of version inconsistencies
+  during releases.
+
 5.2.0 (2025-11-20)
 ++++++++++++++++++
 

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -41,7 +41,6 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-perl -pi -e "s/(?<=__version__ = \").+?(?=\")/$version/gsm" src/geoip2/__init__.py
 perl -pi -e "s/(?<=^version = \").+?(?=\")/$version/gsm" pyproject.toml
 
 echo $"Test results:"

--- a/src/geoip2/__init__.py
+++ b/src/geoip2/__init__.py
@@ -1,7 +1,5 @@
 """geoip2 client library."""
 
-__title__ = "geoip2"
-__version__ = "5.2.0"
-__author__ = "Gregory Oschwald"
-__license__ = "Apache License, Version 2.0"
-__copyright__ = "Copyright (c) 2013-2025 MaxMind, Inc."
+from importlib.metadata import version
+
+__version__ = version("geoip2")


### PR DESCRIPTION
## Summary

- The version is now retrieved from package metadata at runtime using `importlib.metadata`
- This reduces the chance of version inconsistencies during releases
- Follows the pattern already established in `maxminddb`

## Test plan

- [x] All tests pass (`uv run tox`)
- [x] Verified `geoip2.__version__` returns correct value at runtime
- [ ] Verify Read the Docs builds correctly (RTD config already has `python.install` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)