### PR TITLE
Use aiohttp.encode_basic_auth() instead of deprecated BasicAuth

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,10 @@ History
 * The version is now retrieved from package metadata at runtime using
   ``importlib.metadata``. This reduces the chance of version inconsistencies
   during releases.
+* The async client now builds its ``Authorization`` header with
+  ``aiohttp.encode_basic_auth()`` instead of the ``aiohttp.BasicAuth`` /
+  ``auth=`` parameter, which are deprecated as of aiohttp 3.14.0. As a result,
+  the minimum required ``aiohttp`` version is now 3.14.0.
 
 5.2.0 (2025-11-20)
 ++++++++++++++++++

--- a/src/geoip2/webservice.py
+++ b/src/geoip2/webservice.py
@@ -354,8 +354,14 @@ class AsyncClient(BaseClient):
     async def _session(self) -> aiohttp.ClientSession:
         if not hasattr(self, "_existing_session"):
             self._existing_session = aiohttp.ClientSession(
-                auth=aiohttp.BasicAuth(self._account_id, self._license_key),
-                headers={"Accept": "application/json", "User-Agent": _AIOHTTP_UA},
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": aiohttp.encode_basic_auth(
+                        self._account_id,
+                        self._license_key,
+                    ),
+                    "User-Agent": _AIOHTTP_UA,
+                },
                 timeout=aiohttp.ClientTimeout(total=self._timeout),
             )
 


### PR DESCRIPTION
## STF-604

As of aiohttp 3.14.0, `aiohttp.BasicAuth` and the `auth=` parameter on `ClientSession` are deprecated and will be removed in aiohttp 4.0, emitting `DeprecationWarning`s in CI. This builds the `Authorization` header explicitly with `aiohttp.encode_basic_auth()` in the async client instead.

Only the async (aiohttp) client is affected; the sync client uses `requests` (`.auth`), which is not deprecated.

### Notes
- `encode_basic_auth()` defaults to utf-8 where `BasicAuth` defaulted to latin1. Irrelevant here (numeric account IDs, ASCII license keys), but worth noting.
- The aiohttp floor is already `>=3.14.0` (raised by a prior dependency bump), so `encode_basic_auth` is guaranteed available.
- The existing `webservice_test.py::test_request` already asserts the `Authorization` header value, and passes unchanged (the header bytes are identical to the old `BasicAuth` output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)