### PR TITLE
Add residential sub-object to anonymizer for Insights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,13 @@ def __init__(
     continent: dict[str, Any] | None = None,
     country: dict[str, Any] | None = None,
     # ... other keyword-only parameters
-    **_: Any,  # ignore unknown keys
+    **_: object,  # ignore unknown keys
 ) -> None:
 ```
 
 Key points:
 - Use `*` to enforce keyword-only arguments
-- Accept `**_: Any` to ignore unknown keys from the API
+- Accept `**_: object` to ignore unknown keys from the API
 - Use `| None = None` for optional parameters
 - Boolean fields default to `False` if not present
 
@@ -251,7 +251,7 @@ When creating a new model class:
 3. **Extend the appropriate base class** (e.g., `Country`, `City`, `SimpleModel`)
 4. **Use type hints** for all attributes
 5. **Use keyword-only arguments** with `*` separator
-6. **Accept `**_: Any`** to ignore unknown API keys
+6. **Accept `**_: object`** to ignore unknown API keys
 7. **Provide comprehensive docstrings** for all attributes
 8. **Add corresponding tests** with full coverage
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,13 @@ History
   ``aiohttp.encode_basic_auth()`` instead of the ``aiohttp.BasicAuth`` /
   ``auth=`` parameter, which are deprecated as of aiohttp 3.14.0. As a result,
   the minimum required ``aiohttp`` version is now 3.14.0.
+* A new ``residential`` attribute has been added to
+  ``geoip2.records.Anonymizer``. This is a ``geoip2.records.AnonymizerFeed``
+  object providing residential proxy data for the network and contains the
+  following fields: ``confidence``, ``network_last_seen``, and
+  ``provider_name``. This attribute may be populated even when no other
+  anonymizer attributes are set, so the ``anonymizer`` object may now
+  contain only this attribute.
 
 5.2.0 (2025-11-20)
 ++++++++++++++++++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "docs/*" = ["ALL"]
-"src/geoip2/{models,records}.py" = [ "ANN401", "D107", "PLR0913" ]
+"src/geoip2/{models,records}.py" = [ "D107", "PLR0913" ]
 # FBT003: We use assertIs with boolean literals to verify values are actual
 # booleans (True/False), not just truthy/falsy values
 "tests/*" = ["ANN201", "D", "FBT003"]

--- a/src/geoip2/models.py
+++ b/src/geoip2/models.py
@@ -63,7 +63,7 @@ class Country(Model):
         registered_country: dict[str, Any] | None = None,
         represented_country: dict[str, Any] | None = None,
         traits: dict[str, Any] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self._locales = locales
         self.continent = geoip2.records.Continent(locales, **(continent or {}))
@@ -127,7 +127,7 @@ class City(Country):
         represented_country: dict[str, Any] | None = None,
         subdivisions: list[dict[str, Any]] | None = None,
         traits: dict[str, Any] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(
             locales,
@@ -171,7 +171,7 @@ class Insights(City):
         represented_country: dict[str, Any] | None = None,
         subdivisions: list[dict[str, Any]] | None = None,
         traits: dict[str, Any] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(
             locales,
@@ -301,7 +301,7 @@ class AnonymousIP(SimpleModel):
         is_tor_exit_node: bool = False,
         network: str | None = None,
         prefix_len: int | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(ip_address, network, prefix_len)
         self.is_anonymous = is_anonymous
@@ -345,7 +345,7 @@ class AnonymousPlus(AnonymousIP):
         network_last_seen: str | None = None,
         prefix_len: int | None = None,
         provider_name: str | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(
             is_anonymous=is_anonymous,
@@ -383,7 +383,7 @@ class ASN(SimpleModel):
         autonomous_system_organization: str | None = None,
         network: str | None = None,
         prefix_len: int | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(ip_address, network, prefix_len)
         self.autonomous_system_number = autonomous_system_number
@@ -412,7 +412,7 @@ class ConnectionType(SimpleModel):
         connection_type: str | None = None,
         network: str | None = None,
         prefix_len: int | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(ip_address, network, prefix_len)
         self.connection_type = connection_type
@@ -431,7 +431,7 @@ class Domain(SimpleModel):
         domain: str | None = None,
         network: str | None = None,
         prefix_len: int | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(ip_address, network, prefix_len)
         self.domain = domain
@@ -470,7 +470,7 @@ class ISP(ASN):
         organization: str | None = None,
         network: str | None = None,
         prefix_len: int | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         super().__init__(
             autonomous_system_number=autonomous_system_number,

--- a/src/geoip2/records.py
+++ b/src/geoip2/records.py
@@ -74,7 +74,7 @@ class City(PlaceRecord):
         confidence: int | None = None,
         geoname_id: int | None = None,
         names: dict[str, str] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.confidence = confidence
         self.geoname_id = geoname_id
@@ -102,7 +102,7 @@ class Continent(PlaceRecord):
         code: str | None = None,
         geoname_id: int | None = None,
         names: dict[str, str] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.code = code
         self.geoname_id = geoname_id
@@ -139,7 +139,7 @@ class Country(PlaceRecord):
         is_in_european_union: bool = False,
         iso_code: str | None = None,
         names: dict[str, str] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.confidence = confidence
         self.geoname_id = geoname_id
@@ -172,7 +172,7 @@ class RepresentedCountry(Country):
         iso_code: str | None = None,
         names: dict[str, str] | None = None,
         type: str | None = None,  # noqa: A002
-        **_: Any,
+        **_: object,
     ) -> None:
         self.type = type
         super().__init__(
@@ -239,7 +239,7 @@ class Location(Record):
         metro_code: int | None = None,
         population_density: int | None = None,
         time_zone: str | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.average_income = average_income
         self.accuracy_radius = accuracy_radius
@@ -258,7 +258,7 @@ class MaxMind(Record):
     calling.
     """
 
-    def __init__(self, *, queries_remaining: int | None = None, **_: Any) -> None:
+    def __init__(self, *, queries_remaining: int | None = None, **_: object) -> None:
         self.queries_remaining = queries_remaining
 
 
@@ -297,7 +297,7 @@ class AnonymizerFeed(Record):
         confidence: int | None = None,
         network_last_seen: str | None = None,
         provider_name: str | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.confidence = confidence
         self.network_last_seen = (
@@ -392,7 +392,7 @@ class Anonymizer(Record):
         network_last_seen: str | None = None,
         provider_name: str | None = None,
         residential: dict[str, Any] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.confidence = confidence
         self.is_anonymous = is_anonymous
@@ -434,7 +434,7 @@ class Postal(Record):
         *,
         code: str | None = None,
         confidence: int | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.code = code
         self.confidence = confidence
@@ -468,7 +468,7 @@ class Subdivision(PlaceRecord):
         geoname_id: int | None = None,
         iso_code: str | None = None,
         names: dict[str, str] | None = None,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.confidence = confidence
         self.geoname_id = geoname_id
@@ -764,7 +764,7 @@ class Traits(Record):
         mobile_country_code: str | None = None,
         mobile_network_code: str | None = None,
         is_anycast: bool = False,
-        **_: Any,
+        **_: object,
     ) -> None:
         self.autonomous_system_number = autonomous_system_number
         self.autonomous_system_organization = autonomous_system_organization

--- a/src/geoip2/records.py
+++ b/src/geoip2/records.py
@@ -262,10 +262,58 @@ class MaxMind(Record):
         self.queries_remaining = queries_remaining
 
 
+class AnonymizerFeed(Record):
+    """Contains data for one type of anonymizer detection.
+
+    This class contains data for one type of anonymizer detection,
+    currently residential proxies. Additional feeds may be added in the
+    future.
+
+    This record is returned by ``insights`` as the ``residential`` attribute
+    of :py:class:`Anonymizer`.
+    """
+
+    confidence: int | None
+    """A score ranging from 1 to 99 that represents our percent confidence
+    that the network is currently part of this anonymizer feed. This
+    attribute is only available from the Insights end point.
+    """
+
+    network_last_seen: datetime.date | None
+    """The last day that the network was sighted in our analysis of this
+    anonymizer feed. This attribute is only available from the Insights end
+    point.
+    """
+
+    provider_name: str | None
+    """The name of the provider associated with the network in this
+    anonymizer feed. This attribute is only available from the Insights end
+    point.
+    """
+
+    def __init__(
+        self,
+        *,
+        confidence: int | None = None,
+        network_last_seen: str | None = None,
+        provider_name: str | None = None,
+        **_: Any,
+    ) -> None:
+        self.confidence = confidence
+        self.network_last_seen = (
+            datetime.date.fromisoformat(network_last_seen)
+            if network_last_seen
+            else None
+        )
+        self.provider_name = provider_name
+
+
 class Anonymizer(Record):
     """Contains data for the anonymizer record associated with an IP address.
 
     This class contains the anonymizer data associated with an IP address.
+
+    Note that this object may contain only the ``residential`` attribute.
 
     This record is returned by ``insights``.
     """
@@ -286,6 +334,12 @@ class Anonymizer(Record):
     """The name of the VPN provider (e.g., NordVPN, SurfShark, etc.) associated
     with the network. This attribute is only available from the Insights end
     point.
+    """
+
+    residential: AnonymizerFeed
+    """Residential proxy data for the network associated with the IP address.
+    This may be populated even when no other anonymizer attributes are set.
+    This attribute is only available from the Insights end point.
     """
 
     is_anonymous: bool
@@ -337,6 +391,7 @@ class Anonymizer(Record):
         is_tor_exit_node: bool = False,
         network_last_seen: str | None = None,
         provider_name: str | None = None,
+        residential: dict[str, Any] | None = None,
         **_: Any,
     ) -> None:
         self.confidence = confidence
@@ -352,6 +407,7 @@ class Anonymizer(Record):
             else None
         )
         self.provider_name = provider_name
+        self.residential = AnonymizerFeed(**(residential or {}))
 
 
 class Postal(Record):

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,3 +1,4 @@
+import datetime
 import ipaddress
 import sys
 import unittest
@@ -24,6 +25,11 @@ class TestModels(unittest.TestCase):
                 "is_tor_exit_node": True,
                 "network_last_seen": "2025-04-14",
                 "provider_name": "FooBar VPN",
+                "residential": {
+                    "confidence": 82,
+                    "network_last_seen": "2026-05-11",
+                    "provider_name": "quickshift",
+                },
             },
             "city": {
                 "confidence": 76,
@@ -262,9 +268,31 @@ class TestModels(unittest.TestCase):
         self.assertIs(model.anonymizer.is_tor_exit_node, True)
         self.assertEqual(
             model.anonymizer.network_last_seen,
-            __import__("datetime").date(2025, 4, 14),
+            datetime.date(2025, 4, 14),
         )
         self.assertEqual(model.anonymizer.provider_name, "FooBar VPN")
+
+        # Test anonymizer.residential object
+        self.assertEqual(
+            type(model.anonymizer.residential),
+            geoip2.records.AnonymizerFeed,
+            "geoip2.records.AnonymizerFeed object",
+        )
+        self.assertEqual(model.anonymizer.residential.confidence, 82)
+        self.assertEqual(
+            model.anonymizer.residential.network_last_seen,
+            datetime.date(2026, 5, 11),
+        )
+        self.assertEqual(model.anonymizer.residential.provider_name, "quickshift")
+        self.assertEqual(
+            model.anonymizer.to_dict()["residential"],
+            {
+                "confidence": 82,
+                "network_last_seen": "2026-05-11",
+                "provider_name": "quickshift",
+            },
+            "residential is serialized by to_dict",
+        )
 
     def test_insights_min(self) -> None:
         model = geoip2.models.Insights(["en"], traits={"ip_address": "5.6.7.8"})
@@ -324,6 +352,59 @@ class TestModels(unittest.TestCase):
         self.assertIsNone(model.anonymizer.provider_name)
         self.assertFalse(model.anonymizer.is_anonymous)
         self.assertFalse(model.anonymizer.is_anonymous_vpn)
+        # Test that anonymizer.residential defaults correctly
+        self.assertEqual(
+            type(model.anonymizer.residential),
+            geoip2.records.AnonymizerFeed,
+            "geoip2.records.AnonymizerFeed object",
+        )
+        self.assertIsNone(model.anonymizer.residential.confidence)
+        self.assertIsNone(model.anonymizer.residential.network_last_seen)
+        self.assertIsNone(model.anonymizer.residential.provider_name)
+        self.assertEqual(
+            model.to_dict(),
+            {"traits": {"ip_address": "5.6.7.8"}},
+            "empty anonymizer is not serialized by to_dict",
+        )
+
+    def test_insights_anonymizer_residential_only(self) -> None:
+        # The residential attribute may be populated even when no other
+        # anonymizer attributes are set, so the anonymizer object may
+        # contain only the residential attribute.
+        model = geoip2.models.Insights(
+            ["en"],
+            anonymizer={
+                "residential": {
+                    "confidence": 82,
+                    "network_last_seen": "2026-05-11",
+                    "provider_name": "quickshift",
+                },
+            },
+            traits={"ip_address": "5.6.7.8"},
+        )
+        self.assertIsNone(model.anonymizer.confidence)
+        self.assertIsNone(model.anonymizer.provider_name)
+        self.assertFalse(model.anonymizer.is_anonymous)
+        self.assertEqual(model.anonymizer.residential.confidence, 82)
+        self.assertEqual(
+            model.anonymizer.residential.network_last_seen,
+            datetime.date(2026, 5, 11),
+        )
+        self.assertEqual(model.anonymizer.residential.provider_name, "quickshift")
+        self.assertEqual(
+            model.to_dict(),
+            {
+                "anonymizer": {
+                    "residential": {
+                        "confidence": 82,
+                        "network_last_seen": "2026-05-11",
+                        "provider_name": "quickshift",
+                    },
+                },
+                "traits": {"ip_address": "5.6.7.8"},
+            },
+            "anonymizer contains only residential in to_dict output",
+        )
 
     def test_city_full(self) -> None:
         raw = {


### PR DESCRIPTION
## Summary

The GeoIP Insights web service is adding a `residential` sub-object to the `anonymizer` object. It contains residential proxy data for the network and may be populated even when no other anonymizer properties are set.

- New reusable record for the feed shape (`confidence`, `network_last_seen`, `provider_name`) named `AnonymizerFeed`, so future anonymizer feeds can share it
- New `residential` property on the `Anonymizer` record
- Tests, fixtures, and changelog updated

Also converts the `__import__("datetime")` inline-import hack in tests/models_test.py to a normal top-level import.

## Testing

`pytest` (79 passed), `ruff check`, `ruff format --check`, and `mypy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Residential Proxy anonymizer feed in Insights.
  - Includes provider name, confidence, and network last-seen date.
  - Residential feed may be present even when other anonymizer fields are empty.
  - Network last-seen is parsed into a standard date format.
- **Documentation**
  - Updated release history to document the new residential anonymizer attribute.
- **Tests**
  - Expanded and added assertions to cover residential-only and default/minimal payload behavior.
- **Chores**
  - Updated constructor catch-all type hints and Ruff configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->